### PR TITLE
MAX_VIDEO_LEN value change in RL_Trainer __init__ doesn't actually update the global value of the parameter

### DIFF
--- a/hw1/cs285/infrastructure/rl_trainer.py
+++ b/hw1/cs285/infrastructure/rl_trainer.py
@@ -47,6 +47,9 @@ class RL_Trainer(object):
 
         # Maximum length for episodes
         self.params['ep_len'] = self.params['ep_len'] or self.env.spec.max_episode_steps
+
+        # We need to update our outer `MAX_VIDEO_LEN` value
+        global MAX_VIDEO_LEN
         MAX_VIDEO_LEN = self.params['ep_len']
 
         # Is this env continuous, or self.discrete?


### PR DESCRIPTION
Not sure if this is even a relevant parameter or not, but I'm pretty sure the global value being used by:
* https://github.com/berkeleydeeprlcourse/homework_fall2022/blob/main/hw1/cs285/infrastructure/rl_trainer.py#L179
* https://github.com/berkeleydeeprlcourse/homework_fall2022/blob/main/hw1/cs285/infrastructure/rl_trainer.py#L222. 