### PR TITLE
Update replay_buffer.py

### DIFF
--- a/hw1/cs285/infrastructure/replay_buffer.py
+++ b/hw1/cs285/infrastructure/replay_buffer.py
@@ -18,7 +18,7 @@ class ReplayBuffer(object):
         self.terminals = None
 
     def __len__(self):
-        if self.obs:
+        if self.obs is not None:
             return self.obs.shape[0]
         else:
             return 0


### PR DESCRIPTION
Using __len__ with the old code returns "ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()". I believe that line 21 is trying to check if the list is None. If so, this is a better way.