### PR TITLE
[fix] colab dependencies in hw1

### DIFF
--- a/hw1/cs285/scripts/run_hw1.ipynb
+++ b/hw1/cs285/scripts/run_hw1.ipynb
@@ -96,7 +96,7 @@
         "        xpra \\\n",
         "        xserver-xorg-dev \\\n",
         "        xvfb \\\n",
-        "        python-opengl \\\n",
+        "        python3-opengl \\\n",
         "        ffmpeg"
       ]
     },
@@ -114,6 +114,7 @@
         "%cd $SYM_PATH\n",
         "!git clone https://github.com/berkeleydeeprlcourse/homework_fall2022.git\n",
         "%cd homework_fall2022/hw1\n",
+        "%pip install swig # needed to build box2d in the pip install\n",
         "%pip install -r requirements_colab.txt\n",
         "%pip install -e ."
       ]


### PR DESCRIPTION
The opengl line fixes apt package not found for opengl
```
E: Unable to locate package python-opengl
```

The swig install fixes the box2d install error
```
Building wheels for collected packages: box2d-py
  error: subprocess-exited-with-error
  
  × python setup.py bdist_wheel did not run successfully.
  │ exit code: 1
  ╰─> See above for output.
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
  Building wheel for box2d-py (setup.py) ... error
  ERROR: Failed building wheel for box2d-py
  Running setup.py clean for box2d-py
Failed to build box2d-py
ERROR: Could not build wheels for box2d-py, which is required to install pyproject.toml-based projects
```